### PR TITLE
fix: fix mode selection dropdown on firefox

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -207,9 +207,9 @@ class Application {
                             dropdown.hide();
                         }
                     });
-            
-                    dropdown.find("a").click((event) => {
-                        if (event.target instanceof HTMLElement) {
+
+                    dropdown.on("click", (event) => {
+                        if (event.target.tagName === "A") {
                             updateButtonText(mainButtonId, event.target);
                             dropdown.hide();
                         }


### PR DESCRIPTION
For some reason .find("a") randomly returns an empty list on firefox??? this is kinda of a workaround but it works ig, wouldn't be surprised if its a firefox or jquery bug